### PR TITLE
Fix git clone nvm error

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -87,7 +87,7 @@ define nvm::install (
 
   exec { "git clone ${nvm_repo} ${final_nvm_dir} for ${user}":
     command => "git clone ${nvm_repo} ${final_nvm_dir}",
-    cwd     => $home,
+    cwd     => '/tmp',
     user    => $user,
     unless  => "/usr/bin/test -d ${final_nvm_dir}/.git",
     require => $dependencies,


### PR DESCRIPTION
Set current directory of git::clone's exec to /tmp to get rid of fatals:
fatal: Could not change back to '/root': Permission denied

Fix, found here:
http://mediawiki-commits.wikimedia.narkive.com/9D9M5AlV/gerrit-git-clone-fix-clones-with-unprivileged-users-change-operations-puppet